### PR TITLE
Remove hard-version requirement of railties to work with future Rails Versions

### DIFF
--- a/leaflet-markercluster-rails.gemspec
+++ b/leaflet-markercluster-rails.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir["{lib,vendor}/**/*"] + ["LICENSE.txt", "README.md"]
   gem.require_paths = ["lib"]
-  gem.add_dependency "railties", "~> 3.1"
+  gem.add_dependency "railties", ">= 3.1"
 end


### PR DESCRIPTION
Remove the hard-coded version of railties (~> 3.1) to ge to work with future versions
